### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://wajeedshaikh.visualstudio.com/4c429add-a84b-4ff1-8386-f247907625da/c9bc392e-b163-4414-857c-aed18d673a6f/_apis/work/boardbadge/32b027b3-c482-47b2-8374-3fa89ab050bf)](https://wajeedshaikh.visualstudio.com/4c429add-a84b-4ff1-8386-f247907625da/_boards/board/t/c9bc392e-b163-4414-857c-aed18d673a6f/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://wajeedshaikh.visualstudio.com/4c429add-a84b-4ff1-8386-f247907625da/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.